### PR TITLE
shellcode_hashes: new algorithm and minor fixes

### DIFF
--- a/shellcode_hashes/make_sc_hash_db.py
+++ b/shellcode_hashes/make_sc_hash_db.py
@@ -901,7 +901,7 @@ def rol10WithNullAddHash32(inString,fName):
 
 pseudocode_rol10WithNullAddHash32 = '''acc := 0;
 for c in input_string_with_trailing_NULL {
-   acc := ROL(acc, 0x10):
+   acc := ROL(acc, 10):
    acc := acc + c;
 }
 '''


### PR DESCRIPTION
* Added `rol10WithNullAddHash32`
* Removed an unused variable from `rol` function
* Fixed pseudocode definition for `pseudocode_ror13AddHash32Sub1`
* Decoded symbol name before entry into DB (symbols were showing as `ws2_32.dll!b'inet_addr'`