### PR TITLE
Fix issue #106

### DIFF
--- a/python/flare/idb2pat.py
+++ b/python/flare/idb2pat.py
@@ -218,8 +218,7 @@ def make_func_sig(config, func):
 
     sig += " %02X" % (alen)
     sig += " %04X" % (crc)
-    # TODO: does this need to change for 64bit?
-    sig += " %04X" % (func.end_ea - func.start_ea)
+    sig += " %08X" % (func.end_ea - func.start_ea)
 
     # this will be either " :%04d %s" or " :%08d %s"
     public_format = " :%%0%dX %%s" % (config.pointer_size)


### PR DESCRIPTION
Hello,

I tested [this comment](https://github.com/mandiant/flare-ida/issues/106#issuecomment-1699469142) fix, and it seems to work, so here is the PR.

## Context
Some context about issue #106: an error occurs within sigmake while processing pattern files that provide invalid function length, with "invalid" meaning that the function length should be an hexadecimal number with either 8 or 4 digits. In the current code of `idb2pat`, function sizes were calculated to at least 4 digits, but not forced to 8 digits if the number exceeds 4 digits. Analyzing any function which size exceeds 0xFFFF would result in an invalid pattern file.

## The fix

Changed the `%04X` format to `%08X` format. This should not have any impact on the signature generation.

## Testing the PR

The following shows what I did to test this PR.

Create a simple C program such as:
```C
#include<stdio.h>
#include <stdlib.h>

int call_h(){
    int x = 2;
    int y = 4;
    puts("Hello");
    return x * 4 - 2;
}

void main(){
    printf("%x\n", call_h());
}
```

Compile it:
```
gcc -m32 a.c -o a32.out
gcc a.c -o a.out
```
Then:
- create pat signatures with idb2pat
- create a valid signature with sigmake
- stripp the executables and load them in IDA to check that the signature applies correctly.

I also tried on `serde_derive_internals` executable from Rust's `serde` crate, which has a proc_macro function that was exceeding 0xFFFF bytes, and it works perfectly.